### PR TITLE
Add jsconfig for module resolution

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": { "shared/*": ["shared/*"] }
+  },
+  "exclude": ["**/__fixtures__/**"]
+}


### PR DESCRIPTION
## Summary
- add `jsconfig.json` to set up module resolution for shared code

## Testing
- `yarn test` *(fails: Flow reported a type error)*

------
https://chatgpt.com/codex/tasks/task_e_6866d51bdb50832482cf3c0f54331486