### PR TITLE
Switch GitHub workflow to Yarn

### DIFF
--- a/.github/workflows/master_flatristst.yml
+++ b/.github/workflows/master_flatristst.yml
@@ -23,11 +23,11 @@ jobs:
         with:
           node-version: '20.x'
 
-      - name: npm install, build, and test
+      - name: yarn install, build, and test
         run: |
-          npm install
-          npm run build --if-present
-          npm run test --if-present
+          yarn install --frozen-lockfile
+          yarn build
+          yarn test
 
       - name: Zip artifact for deployment
         run: zip -r release.zip web/.next

--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@
 Thanks [@paulgergely](https://twitter.com/paulgergely) for the initial flat design!
 
 Also see [elm-flatris](https://github.com/w0rm/elm-flatris).
+
+## Development
+
+Flatris uses [Yarn](https://yarnpkg.com/) for managing Node dependencies. Make
+sure you have Yarn installed and run `yarn install` to set up the project before
+running `yarn build` or `yarn test`.


### PR DESCRIPTION
## Summary
- use `yarn install --frozen-lockfile` in `master_flatristst.yml`
- run `yarn build` and `yarn test`
- note Yarn requirement in README

## Testing
- `yarn install --frozen-lockfile`
- `yarn build` *(fails: ERR_OSSL_EVP_UNSUPPORTED)*
- `yarn test` *(fails: Found 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_6866eba4b1a8832488424760081321e6