### PR TITLE
Fix release packaging in workflow

### DIFF
--- a/.github/workflows/master_flatristst.yml
+++ b/.github/workflows/master_flatristst.yml
@@ -30,7 +30,7 @@ jobs:
           yarn test
 
       - name: Zip artifact for deployment
-        run: zip -r release.zip web/.next
+        run: zip -r release.zip package.json yarn.lock server web/.next startup ecosystem.config.js
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- update the zip command to include server files and configs
- keep azure/webapps-deploy pointed at `release.zip`

## Testing
- `yarn install`
- `yarn test` *(fails: Cannot call `startServer` with `port` bound to `port` because string is incompatible with number)*

------
https://chatgpt.com/codex/tasks/task_e_686c13444ce883248857f8b2da5b8bc1